### PR TITLE
Feature/multiple tiers

### DIFF
--- a/chamd/cleanCHILDESMD.py
+++ b/chamd/cleanCHILDESMD.py
@@ -441,7 +441,7 @@ def removesuspects(str):
         return result
 		
         
-checkpattern = re.compile(r'[][\(\)&%@/=><_0^~↓↑↑↓⇗↗→↘⇘∞≈≋≡∙⌈⌉⌊⌋∆∇⁎⁇°◉▁▔☺∬Ϋ123456789·\u22A5\u00B7\u0001\u2260\u21AB]')
+checkpattern = re.compile(r'[][\(\)&%@/=><_0^~↓↑↑↓⇗↗→↘⇘∞≈≋≡∙⌈⌉⌊⌋∆∇⁎⁇°◉▁▔☺∬Ϋ·\u22A5\u00B7\u0001\u2260\u21AB]')
 # + should not occur except as compound marker black+board
 # next one split up in order to do substitutions
 pluspattern = re.compile(r'(\W)\+|\+(\W)')

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as file:
 setup(
     name='chamd',
     python_requires='>=3.5, <4',
-    version='0.5.0',
+    version='0.5.1',
     description='Conversion and cleaning of CHILDES CHA files into PaQu Plaintext Metadata Format',
     long_description=long_description,
     author='Digital Humanities Lab, Utrecht University',

--- a/tests/headers.cha
+++ b/tests/headers.cha
@@ -15,6 +15,8 @@
 *DAR:	if only you knew the power of the Dark Side
 *DAR:	Obi-Wan never told you what happened to your father
 %com:	Kenobi
+%xsid:  42
+%add:   spoiler: his son
 *LUK:	he told me enough!
 *LUK:	he told me you killed him!
 *DAR:	no, I am your father.

--- a/tests/headers.txt
+++ b/tests/headers.txt
@@ -94,25 +94,27 @@ if only you knew the power of the Dark Side
 ##META int uttendlineno = 16
 ##META int uttid = 9
 ##META int uttstartlineno = 16
+##META text addressee = spoiler: his son
 ##META text comment = Kenobi
+##META text xsid = 42
 Obi-Wan never told you what happened to your father
 
 
 ##META text origutt = he told me enough!
 ##META text parsefile = Unknown_corpus_headers_u00000000010.xml
 ##META text speaker = LUK
-##META int uttendlineno = 18
+##META int uttendlineno = 20
 ##META int uttid = 10
-##META int uttstartlineno = 18
+##META int uttstartlineno = 20
 he told me enough !
 
 
 ##META text origutt = he told me you killed him!
 ##META text parsefile = Unknown_corpus_headers_u00000000011.xml
 ##META text speaker = LUK
-##META int uttendlineno = 19
+##META int uttendlineno = 21
 ##META int uttid = 11
-##META int uttstartlineno = 19
+##META int uttstartlineno = 21
 he told me you killed him !
 
 
@@ -120,9 +122,9 @@ he told me you killed him !
 ##META text origutt = no, I am your father.
 ##META text parsefile = Unknown_corpus_headers_u00000000012.xml
 ##META text speaker = DAR
-##META int uttendlineno = 20
+##META int uttendlineno = 22
 ##META int uttid = 12
-##META int uttstartlineno = 20
+##META int uttstartlineno = 22
 no , I am your father .
 
 
@@ -130,9 +132,9 @@ no , I am your father .
 ##META text parsefile = Unknown_corpus_headers_u00000000013.xml
 ##META text situation = Dramatic plot twist
 ##META text speaker = LUK
-##META int uttendlineno = 22
+##META int uttendlineno = 24
 ##META int uttid = 13
-##META int uttstartlineno = 22
+##META int uttstartlineno = 24
 no ! no ! that’s not true ! that’s impossible !
 
 
@@ -141,9 +143,9 @@ no ! no ! that’s not true ! that’s impossible !
 ##META text parsefile = Unknown_corpus_headers_u00000000014.xml
 ##META text situation = Dramatic plot twist
 ##META text speaker = DAR
-##META int uttendlineno = 23
+##META int uttendlineno = 25
 ##META int uttid = 14
-##META int uttstartlineno = 23
+##META int uttstartlineno = 25
 search your feelings
 
 
@@ -152,9 +154,9 @@ search your feelings
 ##META text parsefile = Unknown_corpus_headers_u00000000015.xml
 ##META text situation = Dramatic plot twist
 ##META text speaker = DAR
-##META int uttendlineno = 24
+##META int uttendlineno = 26
 ##META int uttid = 15
-##META int uttstartlineno = 24
+##META int uttstartlineno = 26
 you know it to be true !
 
 
@@ -162,9 +164,9 @@ you know it to be true !
 ##META text parsefile = Unknown_corpus_headers_u00000000016.xml
 ##META text situation = Dramatic plot twist
 ##META text speaker = LUK
-##META int uttendlineno = 25
+##META int uttendlineno = 27
 ##META int uttid = 16
-##META int uttstartlineno = 25
+##META int uttstartlineno = 27
 NOOOOOOO ! NOOOOOOOO ! ! !
 
 

--- a/tests/laura29.txt
+++ b/tests/laura29.txt
@@ -272,6 +272,7 @@ hoeveelste is het vandaag , eh de .
 ##META int uttendlineno = 24
 ##META int uttid = 13
 ##META int uttstartlineno = 24
+##META text xexe = another example
 ##META text xfoo = multi line
 nee joh .
 


### PR DESCRIPTION
This resolves #8 
Also fixes undocumented issue where numbers in the text would be incorrectly removed from the cleaned results (e.g. `44ste` -> `ste`).